### PR TITLE
MYSQLDATAPATH -D arg & various fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,14 +36,14 @@ Examples
 Load a **test** PASTSTAT database and the standardized person table into a MySQL database on `localhost` named `patstat2016a` -- note the `-t` modifier. Zipped table files have been placed into the default folder `./data`.
 
 ```
-$ ./load_patstat.sh -u<USER> -p<PASSWORD> -hlocalhost -d patstat2016a -t -n
+$ ./load_patstat.sh -u<USER> -p<PASSWORD> -hlocalhost -d patstat2016a -t
 
 ```
 
 Load a **full** PATSTAT database and the standardized person table into a `localhost` MySQL database `patstat2016a`. Again, zipped table files have been placed into the default folder `./data`.
 
 ```
-$ ./load_patstat.sh -u<USER> -p<PASSWORD> -hlocalhost -d patstat2016a -n
+$ ./load_patstat.sh -u<USER> -p<PASSWORD> -hlocalhost -d patstat2016a
 
 ```
 

--- a/load_patstat.sh
+++ b/load_patstat.sh
@@ -104,7 +104,7 @@ load_table() {
 	# the original sed expr is
 	# sed -e 's/\\\("[^\"]$\)/\1/g'
 	# but we've to add some extra quotes in order to put the command in a shell variable
-	SED_FIX_1=`echo sed -e 's/\\\\\\("[^\"]$\\)/\1/g'`
+	SED_FIX_1=`echo sed -e 's/\\\\\\+\\("[^\"]$\\)/\1/g'`
 
 	# other rows are bugged as well since the cotain one or more backslash just before some double quote
 	# separating different columns

--- a/load_patstat.sh
+++ b/load_patstat.sh
@@ -22,6 +22,7 @@ function show_help() {
     echo "  -t: load small chunks of data for testing purposes"
     echo "  -z: directory containing patstat zipped files shipped in DVDs (defaults to $ZIPFILESPATH)"
     echo "  -o: output and error logs directory (defaults to $LOGPATH)"
+    echo "  -D: MySQL data directory path (defaults to $MYSQLDATAPATH)"
 }
 
 while getopts "?vto:u:p:d:h:z:m:" opt; do
@@ -43,6 +44,8 @@ while getopts "?vto:u:p:d:h:z:m:" opt; do
     h)  HOST=$OPTARG
 	;;
     d)  DB=$OPTARG
+	;;
+    D)  MYSQLDATAPATH=$OPTARG
 	;;
     z)  ZIPFILESPATH=$OPTARG
 	;;


### PR DESCRIPTION
- Added a -D option to specify MYSQLDATAPATH at the command line
- removed unused -n option in examples in README.md
- redoing the SED_FIX_1? Don't know where that went ...
